### PR TITLE
Move some dependencies into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,17 +36,17 @@
     "windows"
   ],
   "dependencies": {
-    "chai": "^4.1.1",
-    "chai-as-promised": "^7.1.1",
     "defaultcss": "^1.1.1",
-    "domify": "^1.4.0",
-    "eslint": "^4.4.0",
-    "mocha": "^3.5.0",
-    "mocha-better-spec-reporter": "^3.1.0"
+    "domify": "^1.4.0"
   },
   "devDependencies": {
     "electron": "^1.6.11",
-    "spectron": "^3.7.2"
+    "spectron": "^3.7.2",
+    "chai": "^4.1.1",
+    "chai-as-promised": "^7.1.1",
+    "eslint": "^4.4.0",
+    "mocha": "^3.5.0",
+    "mocha-better-spec-reporter": "^3.1.0"
   },
   "main": "./lib/titlebar.js",
   "scripts": {


### PR DESCRIPTION
I was using `yarn why x` to see why I had so many dependencies after building an electron app.
`eslint` and many other things are listed in dependencies whereas they should be devDependencies.